### PR TITLE
Allow text 2.0

### DIFF
--- a/jira-wiki-markup.cabal
+++ b/jira-wiki-markup.cabal
@@ -41,7 +41,7 @@ library
   build-depends:       base    >= 4.9   && < 5
                      , mtl     >= 2.2   && < 2.3
                      , parsec  >= 3.1   && < 3.2
-                     , text    >= 1.1.1 && < 1.3
+                     , text    >= 1.1.1 && < 1.3 || >= 2.0 && < 2.1
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns
@@ -60,7 +60,7 @@ executable jira-wiki-markup
   main-is:             Main.hs
 
   build-depends:       base    >= 4.9   && < 5
-                     , text    >= 1.1.1 && < 1.3
+                     , text    >= 1.1.1 && < 1.3 || >= 2.0 && < 2.1
                      , jira-wiki-markup
 
   ghc-options:         -Wall
@@ -92,7 +92,7 @@ test-suite jira-wiki-markup-test
                      , parsec  >= 3.1   && < 3.2
                      , tasty
                      , tasty-hunit
-                     , text    >= 1.1.1 && < 1.3
+                     , text    >= 1.1.1 && < 1.3 || >= 2.0 && < 2.1
 
   ghc-options:         -Wall
                        -threaded


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'text == 2.0' || break ; done` passed:

```
Configuring library for jira-wiki-markup-1.4.0..
Preprocessing library for jira-wiki-markup-1.4.0..
Building library for jira-wiki-markup-1.4.0..
[1 of 8] Compiling Text.Jira.Markup
[2 of 8] Compiling Text.Jira.Parser.Core
[3 of 8] Compiling Text.Jira.Parser.Shared
[4 of 8] Compiling Text.Jira.Parser.Inline
[5 of 8] Compiling Text.Jira.Parser.PlainText
[6 of 8] Compiling Text.Jira.Parser.Block
[7 of 8] Compiling Text.Jira.Parser
[8 of 8] Compiling Text.Jira.Printer
Configuring test suite 'jira-wiki-markup-test' for jira-wiki-markup-1.4.0..
Configuring executable 'jira-wiki-markup' for jira-wiki-markup-1.4.0..
Preprocessing executable 'jira-wiki-markup' for jira-wiki-markup-1.4.0..
Building executable 'jira-wiki-markup' for jira-wiki-markup-1.4.0..
Preprocessing test suite 'jira-wiki-markup-test' for jira-wiki-markup-1.4.0..
Building test suite 'jira-wiki-markup-test' for jira-wiki-markup-1.4.0..
[1 of 1] Compiling Main
[1 of 5] Compiling Text.Jira.Parser.BlockTests
Linking /dev/shm/jira-wiki-markup/dist-newstyle/build/x86_64-linux/ghc-9.2.2/jira-wiki-markup-1.4.0/x/jira-wiki-markup/build/jira-wiki-markup/jira-wiki-markup ...
[2 of 5] Compiling Text.Jira.Parser.InlineTests
[3 of 5] Compiling Text.Jira.ParserTests
[4 of 5] Compiling Text.Jira.PrinterTests
[5 of 5] Compiling Main
Linking /dev/shm/jira-wiki-markup/dist-newstyle/build/x86_64-linux/ghc-9.2.2/jira-wiki-markup-1.4.0/t/jira-wiki-markup-test/build/jira-wiki-markup-test/jira-wiki-markup-test ...
Build profile: -w ghc-9.2.2 -O1
In order, the following will be built (use -v for more details):
 - jira-wiki-markup-1.4.0 (test:jira-wiki-markup-test) (ephemeral targets)
Preprocessing test suite 'jira-wiki-markup-test' for jira-wiki-markup-1.4.0..
Building test suite 'jira-wiki-markup-test' for jira-wiki-markup-1.4.0..
Running 1 test suites...
Test suite jira-wiki-markup-test: RUNNING...
Test suite jira-wiki-markup-test: PASS
Test suite logged to:
/dev/shm/jira-wiki-markup/dist-newstyle/build/x86_64-linux/ghc-9.2.2/jira-wiki-markup-1.4.0/t/jira-wiki-markup-test/test/jira-wiki-markup-1.4.0-jira-wiki-markup-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```