### PR TITLE
Allow mtl 2.3.1

### DIFF
--- a/jira-wiki-markup.cabal
+++ b/jira-wiki-markup.cabal
@@ -63,7 +63,7 @@ library
                      , Text.Jira.Parser.Shared
                      , Text.Jira.Printer
 
-  build-depends:       mtl     >= 2.2   && < 2.3
+  build-depends:       mtl     >= 2.2   && < 2.4
                      , parsec  >= 3.1   && < 3.2
 
 


### PR DESCRIPTION
Tested with GHC 9.2.4 by running `for action in build test ; do cabal $action --enable-tests --constrain 'mtl == 2.3.1' || break ; done`.